### PR TITLE
Added method to update existing transaction and modified the cached client

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See below whats implemented (Not fully updated yet)
 |/budgets/{budget_id}/transactions|POST|Creates a single transaction or multiple transactions.  If you provide a body containing a 'transaction' object, a single transaction will be created and if you provide a body containing a 'transactions' array, multiple transactions will be created.|YES|
 |/budgets/{budget_id}/transactions|PATCH|Updates multiple transactions, by 'id' or 'import_id'.|NO|
 |/budgets/{budget_id}/transactions/{transaction_id}|GET|Returns a single transaction|YES|
-|/budgets/{budget_id}/transactions/{transaction_id}|PUT|Updates a transaction|NO|
+|/budgets/{budget_id}/transactions/{transaction_id}|PUT|Updates a transaction|YES|
 |/budgets/{budget_id}/transactions/bulk|POST|Creates multiple transactions.  Although this endpoint is still supported, it is recommended to use 'POST /budgets/{budget_id}/transactions' to create multiple transactions.|NO|
 |/budgets/{budget_id}/accounts/{account_id}/transactions|GET|Returns all transactions for a specified account|NO|
 |/budgets/{budget_id}/categories/{category_id}/transactions|GET|Returns all transactions for a specified category|NO|

--- a/test/support/dummy_client.py
+++ b/test/support/dummy_client.py
@@ -17,3 +17,6 @@ class DummyClient(BaseClient):
 
     def post(self, endpoint: str, payload: dict):
         pass
+
+    def put(self, endpoint: str, payload: dict):
+        pass

--- a/test/support/mock.py
+++ b/test/support/mock.py
@@ -10,3 +10,10 @@ def build_post_mock():
         return {}
 
     return mock_post
+
+
+def build_put_mock():
+    def mock_put(_self, _endpoint, _payload):
+        return {}
+
+    return mock_put

--- a/test/test_api/test_transactions.py
+++ b/test/test_api/test_transactions.py
@@ -27,6 +27,14 @@ class TransactionsTest(SpyAgency, TestCase):
         self.assertIsNotNone(transactions)
         self.assertIsInstance(transactions, TransactionsResponse)
 
+    def test_get_transactions_from_account_with_success(self):
+        spy = self.spy_on(self.client.get, call_fake=build_get_mock(transaction_fixtures.VALID_TRANSACTIONS))
+        transactions = self.ynab.transactions.get_transactions_from_account('some-budget', 'some-account')
+
+        self.assertTrue(spy.called_with('/budgets/some-budget/accounts/some-account/transactions'))
+        self.assertIsNotNone(transactions)
+        self.assertIsInstance(transactions, TransactionsResponse)
+
     def test_create_transactions_with_success(self):
         spy = self.spy_on(self.client.post, call_fake=build_post_mock())
         transactions = [TransactionRequest('some-account', 'some-date', 123123)]

--- a/test/test_api/test_transactions.py
+++ b/test/test_api/test_transactions.py
@@ -5,7 +5,7 @@ from kgb import SpyAgency
 
 import test.support.fixtures.transactions as transaction_fixtures
 from test.support.dummy_client import DummyClient
-from test.support.mock import build_get_mock, build_post_mock
+from test.support.mock import build_get_mock, build_post_mock, build_put_mock
 from ynab_sdk import YNAB
 from ynab_sdk.api.models.requests.transaction import TransactionRequest
 from ynab_sdk.api.models.responses.transactions import TransactionsResponse
@@ -43,4 +43,14 @@ class TransactionsTest(SpyAgency, TestCase):
         payload = {'transactions': [dataclasses.asdict(t) for t in transactions]}
 
         self.assertTrue(spy.called_with('/budgets/some-budget/transactions', payload))
+        self.assertIsNotNone(response)
+
+    def test_update_transaction_with_success(self):
+        spy = self.spy_on(self.client.put, call_fake=build_put_mock())
+        transaction = TransactionRequest('some-account', 'some-date', 123123)
+        response = self.ynab.transactions.update_transaction('some-budget', 'some-transaction', transaction)
+
+        payload = {'transaction': dataclasses.asdict(transaction)}
+
+        self.assertTrue(spy.called_with('/budgets/some-budget/transactions/some-transaction', payload))
         self.assertIsNotNone(response)

--- a/test/test_utils/clients/test_cached_client.py
+++ b/test/test_utils/clients/test_cached_client.py
@@ -32,6 +32,13 @@ def fake_post(url, data=None, json=None, **kwargs):
     return response
 
 
+def fake_put(url, data=None, json=None, **kwargs):
+    response = Mock(spec=Response)
+    type(response).status_code = PropertyMock(return_value=200)
+    response.json.return_value = {}
+    return response
+
+
 def fake_redis_set(self, name, value, ex=None, px=None, nx=False, xx=False):
     return
 
@@ -85,3 +92,8 @@ class CachedClientTest(SpyAgency, TestCase):
         spy = self.spy_on(requests.post, call_fake=fake_post)
         payload = {'key': 'value'}
         self.client.post('/some-endpoint', payload)
+
+    def test_succesful_put(self):
+        spy = self.spy_on(requests.put, call_fake=fake_put)
+        payload = {'key': 'value'}
+        self.client.put('/some-endpoint', payload)

--- a/test/test_utils/clients/test_default_client.py
+++ b/test/test_utils/clients/test_default_client.py
@@ -21,6 +21,12 @@ def fake_post(url, data=None, json=None, **kwargs):
     return response
 
 
+def fake_put(url, data=None, json=None, **kwargs):
+    response = Mock(spec=Response)
+    response.json.return_value = {}
+    return response
+
+
 class DefaultClientTest(SpyAgency, TestCase):
     config: DefaultConfig
     client: DefaultClient
@@ -41,4 +47,8 @@ class DefaultClientTest(SpyAgency, TestCase):
         spy = self.spy_on(requests.post, call_fake=fake_post)
         payload = {'key': 'value'}
         self.client.post('/some-endpoint', payload)
-   
+
+    def test_succesful_put(self):
+        spy = self.spy_on(requests.put, call_fake=fake_put)
+        payload = {'key': 'value'}
+        self.client.post('/some-endpoint', payload)

--- a/ynab_sdk/api/transactions.py
+++ b/ynab_sdk/api/transactions.py
@@ -15,6 +15,10 @@ class TransactionsApi:
         response = self.client.get(f'/budgets/{budget_id}/transactions')
         return TransactionsResponse.from_dict(response)
 
+    def get_transactions_from_account(self, budget_id: str, account_id: str) -> TransactionsResponse:
+        response = self.client.get(f'/budgets/{budget_id}/accounts/{account_id}/transactions')
+        return TransactionsResponse.from_dict(response)
+
     def create_transactions(self, budget_id: str, transactions: List[TransactionRequest]):
         payload = {
             'transactions': [dataclasses.asdict(t) for t in transactions]

--- a/ynab_sdk/api/transactions.py
+++ b/ynab_sdk/api/transactions.py
@@ -24,3 +24,9 @@ class TransactionsApi:
             'transactions': [dataclasses.asdict(t) for t in transactions]
         }
         return self.client.post(f'/budgets/{budget_id}/transactions', payload)
+
+    def update_transaction(self, budget_id: str, transaction_id: str, transaction: TransactionRequest):
+        payload = {
+            'transaction': dataclasses.asdict(transaction)
+        }
+        return self.client.put(f'/budgets/{budget_id}/transactions/{transaction_id}', payload)

--- a/ynab_sdk/utils/clients/base_client.py
+++ b/ynab_sdk/utils/clients/base_client.py
@@ -18,6 +18,10 @@ class BaseClient(ABC):
     def post(self, endpoint: str, payload: dict):
         raise NotImplementedError()
 
+    @abstractmethod
+    def put(self, endpoint: str, payload: dict):
+        raise NotImplementedError()
+
     @property
     def headers(self):
         return {

--- a/ynab_sdk/utils/clients/cached_client.py
+++ b/ynab_sdk/utils/clients/cached_client.py
@@ -27,7 +27,10 @@ class CachedClient(BaseClient):
             response = requests.get(url, headers=self.headers)
             data = response.json()
             if response.status_code == 200:
-                self.redis.set(endpoint, json.dumps(data))
+                if self.redis_TTL > 0:
+                    self.redis.setex(endpoint, self.redis_TTL, json.dumps(data))
+                else:
+                    self.redis.set(endpoint, json.dumps(data))
             else:
                 self.logger.error(f'Error when getting {url}')
                 self.logger.error(data)
@@ -37,4 +40,9 @@ class CachedClient(BaseClient):
     def post(self, endpoint: str, payload: dict):
         url = self.config.full_url + endpoint
         response = requests.post(url, json=payload, headers=self.headers)
+        return response.json()
+
+    def put(self, endpoint: str, payload: dict):
+        url = self.config.full_url + endpoint
+        response = requests.put(url, json=payload, headers=self.headers)
         return response.json()

--- a/ynab_sdk/utils/clients/cached_client.py
+++ b/ynab_sdk/utils/clients/cached_client.py
@@ -12,6 +12,7 @@ class CachedClient(BaseClient):
     def __init__(self, config: CachedConfig):
         super().__init__(config)
         self.redis = Redis(host=config.redis_host, port=config.redis_port, db=config.redis_db)
+        self.redis_TTL = config.redis_TTL
 
     def get(self, endpoint: str):
         self.logger.error(f'Endpoint => {endpoint}')

--- a/ynab_sdk/utils/clients/default_client.py
+++ b/ynab_sdk/utils/clients/default_client.py
@@ -21,3 +21,8 @@ class DefaultClient(BaseClient):
         url = self.config.full_url + endpoint
         response = requests.post(url, json=payload, headers=self.headers)
         return response.json()
+
+    def put(self, endpoint: str, payload: dict):
+        url = self.config.full_url + endpoint
+        response = requests.put(url, json=payload, headers=self.headers)
+        return response.json()

--- a/ynab_sdk/utils/configurations/cached.py
+++ b/ynab_sdk/utils/configurations/cached.py
@@ -3,8 +3,9 @@ from ynab_sdk.utils.configurations.default import DefaultConfig
 
 class CachedConfig(DefaultConfig):
 
-    def __init__(self, redis_host: str, redis_port: int, redis_db: int = 0, **kwargs):
+    def __init__(self, redis_host: str, redis_port: int, redis_db: int = 0, redis_TTL: int = 3600, **kwargs):
         super().__init__(**kwargs)
         self.redis_host = redis_host
         self.redis_port = redis_port
         self.redis_db = redis_db
+        self.redis_TTL = redis_TTL


### PR DESCRIPTION
Added a method to update an existing transaction.
Modified the clients to support PUT requests.

Modified the cached client to implement expiring cached data by default. TTL is set by default to 3600 seconds (1 hour), if set to 0 or negative, the cached data never expires