### PR TITLE
Fix issue with goal_type being mapped to note for categories when using the budget detail endpoint

### DIFF
--- a/ynab_sdk/api/models/responses/budget_detail.py
+++ b/ynab_sdk/api/models/responses/budget_detail.py
@@ -85,7 +85,7 @@ class Category:
         activity = parsers.from_int(obj.get("activity"))
         balance = parsers.from_int(obj.get("balance"))
         goal_type = parsers.from_union(
-            [parsers.from_str, parsers.from_none], obj.get("note")
+            [parsers.from_str, parsers.from_none], obj.get("goal_type")
         )
         goal_creation_month = parsers.from_union(
             [parsers.from_str, parsers.from_none], obj.get("goal_creation_month")


### PR DESCRIPTION
This is a fix for issue #102 